### PR TITLE
Fix peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
-    "react": ">=15.0.0 <16.0.0",
-    "react-native": ">=40.0.0 <1.0.0"
+    "react": "^15.0.0 || ^16.0.0-alpha",
+    "react-native": "^0.40.0"
   }
 }


### PR DESCRIPTION
`^15.0.0` is equivalent to `>=15.0.0 <16.0.0`

also current `react-native@0.47.1` depends on `react@16.0.0-alpha.12`.