### PR TITLE
Add ability to disable interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The number of pixels between the adjacent card and its next card.
 The angle in degrees at which the non centered cards needs to be rotated.
 
 ### midRotation :number default 50
-The angle at which the center card needs to rotate to during transition. 
+The angle at which the center card needs to rotate to during transition.
 Use this value to make sure that during the central card transition, the
 cards do not overlap.
 
@@ -71,3 +71,6 @@ A scale factor for the card adjacent to the center.
 
 ### scaleFurther :number default 0.75
 A diminising scale factor for the card next to the adjacent card.
+
+### disableInteraction :boolean default false
+Disable swipe and press interactions completely.

--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -230,6 +230,7 @@ class Coverflow extends Component {
 
   render() {
     const {
+      disableInteraction,
       style,
       rotation,
       midRotation,
@@ -247,7 +248,7 @@ class Coverflow extends Component {
         style={[styles.container, style]}
         {...props}
         onLayout={this.onLayout}
-        {...this.panResponder.panHandlers}
+        {...(disableInteraction ? {} : this.panResponder.panHandlers)}
       >
         {children.map(this.renderItem)}
       </View>

--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -80,7 +80,7 @@ class Coverflow extends Component {
       onMoveShouldSetPanResponder: (evt, gestureState) => (
         // Since we want to handle presses on individual items as well
         // Only start the pan responder when there is some movement
-        Math.abs(gestureState.dx) > 10 && !this.props.disableInteraction
+        Math.abs(gestureState.dx) > 10
       ),
       onPanResponderGrant: () => {
         scrollX.stopAnimation();
@@ -141,19 +141,17 @@ class Coverflow extends Component {
   }
 
   onScroll = ({ value }) => {
-    if (!this.props.disableInteraction) {
-      // Update the most recent value
-      this.scrollPos = value;
+    // Update the most recent value
+    this.scrollPos = value;
 
-      const count = this.state.children.length;
+    const count = this.state.children.length;
 
-      const newSelection = clamp(Math.round(value), 0, count - 1);
-      if (newSelection !== this.state.selection) {
-        this.setState({
-          selection: newSelection,
-          children: fixChildrenOrder(this.props, newSelection),
-        });
-      }
+    const newSelection = clamp(Math.round(value), 0, count - 1);
+    if (newSelection !== this.state.selection) {
+      this.setState({
+        selection: newSelection,
+        children: fixChildrenOrder(this.props, newSelection),
+      });
     }
   }
 

--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -162,15 +162,13 @@ class Coverflow extends Component {
   }
 
   onSelect = (idx) => {
-    if (!this.props.disableInteraction) {
-      // Check if the current selection is "exactly" the same
-      if (idx === Math.round(this.scrollPos)) {
-        if (this.props.onPress) {
-          this.props.onPress(idx);
-        }
-      } else {
-        this.snapToPosition(idx);
+    // Check if the current selection is "exactly" the same
+    if (idx === Math.round(this.scrollPos)) {
+      if (this.props.onPress) {
+        this.props.onPress(idx);
       }
+    } else {
+      this.snapToPosition(idx);
     }
   }
 
@@ -203,6 +201,7 @@ class Coverflow extends Component {
       scaleFurther,
       spacing,
       wingSpan,
+      disableInteraction
     } = this.props;
     const count = Children.count(children);
 
@@ -220,6 +219,7 @@ class Coverflow extends Component {
         scaleDown={scaleDown}
         scaleFurther={scaleFurther}
         onSelect={this.onSelect}
+        disableInteraction={disableInteraction}
       >
         {item}
       </Item>

--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -37,6 +37,7 @@ class Coverflow extends Component {
     children: PropTypes.arrayOf(PropTypes.element).isRequired,
     onPress: PropTypes.func,
     onChange: PropTypes.func.isRequired,
+    disableInteraction: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -52,6 +53,7 @@ class Coverflow extends Component {
     scaleDown: 0.8,
     scaleFurther: 0.75,
     onPress: undefined,
+    disableInteraction: false,
   };
 
   constructor(props) {
@@ -78,7 +80,7 @@ class Coverflow extends Component {
       onMoveShouldSetPanResponder: (evt, gestureState) => (
         // Since we want to handle presses on individual items as well
         // Only start the pan responder when there is some movement
-        Math.abs(gestureState.dx) > 10
+        Math.abs(gestureState.dx) > 10 && !this.props.disableInteraction
       ),
       onPanResponderGrant: () => {
         scrollX.stopAnimation();
@@ -139,17 +141,19 @@ class Coverflow extends Component {
   }
 
   onScroll = ({ value }) => {
-    // Update the most recent value
-    this.scrollPos = value;
+    if (!this.props.disableInteraction) {
+      // Update the most recent value
+      this.scrollPos = value;
 
-    const count = this.state.children.length;
+      const count = this.state.children.length;
 
-    const newSelection = clamp(Math.round(value), 0, count - 1);
-    if (newSelection !== this.state.selection) {
-      this.setState({
-        selection: newSelection,
-        children: fixChildrenOrder(this.props, newSelection),
-      });
+      const newSelection = clamp(Math.round(value), 0, count - 1);
+      if (newSelection !== this.state.selection) {
+        this.setState({
+          selection: newSelection,
+          children: fixChildrenOrder(this.props, newSelection),
+        });
+      }
     }
   }
 
@@ -160,13 +164,15 @@ class Coverflow extends Component {
   }
 
   onSelect = (idx) => {
-    // Check if the current selection is "exactly" the same
-    if (idx === Math.round(this.scrollPos)) {
-      if (this.props.onPress) {
-        this.props.onPress(idx);
+    if (!this.props.disableInteraction) {
+      // Check if the current selection is "exactly" the same
+      if (idx === Math.round(this.scrollPos)) {
+        if (this.props.onPress) {
+          this.props.onPress(idx);
+        }
+      } else {
+        this.snapToPosition(idx);
       }
-    } else {
-      this.snapToPosition(idx);
     }
   }
 

--- a/src/Item.js
+++ b/src/Item.js
@@ -27,6 +27,7 @@ class Item extends Component {
     scaleDown: PropTypes.number.isRequired,
     scaleFurther: PropTypes.number.isRequired,
     onSelect: PropTypes.func.isRequired,
+    disableInteraction: PropTypes.bool
   };
 
   static childContextTypes = {
@@ -68,6 +69,7 @@ class Item extends Component {
       wingSpan,
       spacing,
       onSelect,
+      disableInteraction,
     } = this.props;
 
     const style = {
@@ -112,7 +114,7 @@ class Item extends Component {
 
     return (
       <View pointerEvents="box-none" style={styles.container}>
-        <TouchableWithoutFeedback onPress={() => onSelect(position)}>
+        <TouchableWithoutFeedback onPress={() => onSelect(position)} disabled={disableInteraction}>
           <Animated.View style={style}>
             {this.props.children}
           </Animated.View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,10 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -890,6 +894,10 @@ convert-source-map@^1.1.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -1024,6 +1032,12 @@ ecc-jsbn@~0.1.1:
 emoji-regex@^6.1.0:
   version "6.4.2"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 "errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
@@ -1334,6 +1348,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -1627,6 +1653,12 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
+iconv-lite@~0.4.13:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 ignore@^3.2.0:
   version "3.2.7"
   resolved "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"
@@ -1811,6 +1843,10 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
@@ -1836,6 +1872,13 @@ isobject@^2.0.0:
   resolved "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2251,7 +2294,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2341,6 +2384,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2411,7 +2461,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2613,6 +2663,20 @@ process@~0.5.1:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.6.0:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -2836,6 +2900,10 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
 sane@~1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/sane/-/sane-1.5.0.tgz#a4adeae764d048621ecb27d5f9ecf513101939f3"
@@ -2863,6 +2931,10 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 shelljs@^0.7.5:
   version "0.7.7"
@@ -3114,6 +3186,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+ua-parser-js@^0.7.9:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
+
 uglify-js@^2.6:
   version "2.8.22"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
@@ -3191,6 +3267,10 @@ whatwg-encoding@^1.0.1:
   resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
   dependencies:
     iconv-lite "0.4.13"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 whatwg-url@^4.3.0:
   version "4.7.0"


### PR DESCRIPTION
I needed the ability to disable interactions so I added a prop for this.

I'm working on a browser - it has a coverflow mode (for switching tabs) and a non-coverflow mode (for viewing the active tab). In the latter mode I needed to stop the user from being able to change tabs via swipes or press the tab (since that doesn't make sense in this mode anyway).

This prop enables me to do this without having to render two different component subtrees (thus causing the tabs to re-mounted everytime modes are switched).